### PR TITLE
Feature 3 & 4: View calendar list and view calendar details

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -10,6 +10,22 @@ h1 {
   min-width: 270px;
 }
 
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .spin {
+    animation: spin infinite 2s linear;
+  }
+}
+
 /* .logo {
   height: 6em;
   padding: 1.5em;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,7 @@ import { Header } from './components/Header.tsx';
 import { Home } from './pages/Home.tsx';
 import { Register } from './pages/Register.tsx';
 import { SignIn } from './pages/SignIn.tsx';
-import { Calendar } from './pages/Calendar.tsx';
+import { CalendarDetails } from './pages/CalendarDetails.tsx';
 import { NotFound } from './pages/NotFound.tsx';
 
 export default function App() {
@@ -19,7 +19,7 @@ export default function App() {
           <Route index element={<Home />} />
           <Route path="/register" element={<Register />} />
           <Route path="/sign-in" element={<SignIn />} />
-          <Route path="/calendar/:calendarId" element={<Calendar />} />
+          <Route path="/calendar/:calendarId" element={<CalendarDetails />} />
           <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,13 +2,14 @@ import { Route, Routes } from 'react-router-dom';
 
 import { UserProvider } from './components/UserContext';
 
+import './App.css';
+
 import { Header } from './components/Header.tsx';
 import { Home } from './pages/Home.tsx';
 import { Register } from './pages/Register.tsx';
 import { SignIn } from './pages/SignIn.tsx';
+import { Calendar } from './pages/Calendar.tsx';
 import { NotFound } from './pages/NotFound.tsx';
-
-import './App.css';
 
 export default function App() {
   return (
@@ -18,6 +19,7 @@ export default function App() {
           <Route index element={<Home />} />
           <Route path="/register" element={<Register />} />
           <Route path="/sign-in" element={<SignIn />} />
+          <Route path="/calendar/:calendarId" element={<Calendar />} />
           <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/client/src/components/HabitMarker.tsx
+++ b/client/src/components/HabitMarker.tsx
@@ -5,29 +5,41 @@ type Props = {
   color: string;
 };
 export function HabitMarker({ mark, color }: Props) {
-  let buttonStyle = 'rounded-full border-[5px]';
+  let buttonStyle =
+    'rounded-full border-[5px] w-[50px] h-[50px] cursor-pointer';
+
+  if (!mark) {
+    buttonStyle += ' big:hover:bg-[#64646420]';
+  }
 
   switch (color) {
     case 'red':
-      buttonStyle += ' bg-[#FF5A5A] border-[#FF5A5A]';
+      buttonStyle += ' border-[#FF5A5A]';
+      if (mark) buttonStyle += ' bg-[#FF5A5A]';
       break;
     case 'orange':
-      buttonStyle += ' bg-[#F29930] border-[#F29930]';
+      buttonStyle += ' border-[#F29930]';
+      if (mark) buttonStyle += ' bg-[#F29930]';
       break;
     case 'yellow':
-      buttonStyle += ' bg-[#F2EA30] border-[#F2EA30]';
+      buttonStyle += ' border-[#F2EA30]';
+      if (mark) buttonStyle += ' bg-[#F2EA30]';
       break;
     case 'green':
-      buttonStyle += ' bg-[#31F22D] border-[#31F22D]';
+      buttonStyle += ' border-[#31F22D]';
+      if (mark) buttonStyle += ' bg-[#31F22D]';
       break;
     case 'blue':
-      buttonStyle += ' bg-[#35E6F1] border-[#35E6F1]';
+      buttonStyle += ' border-[#35E6F1]';
+      if (mark) buttonStyle += ' bg-[#35E6F1]';
       break;
     case 'purple':
-      buttonStyle += ' bg-[#D289FF] border-[#D289FF]';
+      buttonStyle += ' border-[#D289FF]';
+      if (mark) buttonStyle += ' bg-[#D289FF]';
       break;
     case 'pink':
-      buttonStyle += ' bg-[#FF7EFA] border-[#FF7EFA]';
+      buttonStyle += ' border-[#FF7EFA]';
+      if (mark) buttonStyle += ' bg-[#FF7EFA]';
       break;
   }
 

--- a/client/src/components/HabitMarker.tsx
+++ b/client/src/components/HabitMarker.tsx
@@ -1,0 +1,39 @@
+import { FaCheck } from 'react-icons/fa';
+
+type Props = {
+  mark: boolean;
+  color: string;
+};
+export function HabitMarker({ mark, color }: Props) {
+  let buttonStyle = 'rounded-full border-[5px]';
+
+  switch (color) {
+    case 'red':
+      buttonStyle += ' bg-[#FF5A5A] border-[#FF5A5A]';
+      break;
+    case 'orange':
+      buttonStyle += ' bg-[#F29930] border-[#F29930]';
+      break;
+    case 'yellow':
+      buttonStyle += ' bg-[#F2EA30] border-[#F2EA30]';
+      break;
+    case 'green':
+      buttonStyle += ' bg-[#31F22D] border-[#31F22D]';
+      break;
+    case 'blue':
+      buttonStyle += ' bg-[#35E6F1] border-[#35E6F1]';
+      break;
+    case 'purple':
+      buttonStyle += ' bg-[#D289FF] border-[#D289FF]';
+      break;
+    case 'pink':
+      buttonStyle += ' bg-[#FF7EFA] border-[#FF7EFA]';
+      break;
+  }
+
+  return (
+    <button className={buttonStyle} type="button">
+      {mark && <FaCheck />}
+    </button>
+  );
+}

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -17,7 +17,7 @@ export function Header() {
   return (
     <>
       <div>
-        <div className="p-2 px-[15px] flex justify-between">
+        <div className="p-2 px-[15px] flex justify-between sm:px-[50px]">
           <Link
             to="/"
             className="text-[32px] font-bold cursor-pointer"
@@ -40,7 +40,9 @@ export function Header() {
           )}
         </div>
         <hr className="border-[1px]" />
-        <Outlet />
+        <div className="mx-[15px] sm:mx-[50px]">
+          <Outlet />
+        </div>
       </div>
       <Popup
         isOpen={menuIsOpen}

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -2,10 +2,11 @@ import { TiThMenu } from 'react-icons/ti';
 import { Link, Outlet } from 'react-router-dom';
 import { useUser } from './useUser';
 import { Popup } from './Popup';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { readUser } from '../lib';
 
 export function Header() {
-  const { user, handleSignOut } = useUser();
+  const { user, handleSignOut, handleSignIn } = useUser();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   const menuBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -14,17 +15,25 @@ export function Header() {
     setMenuIsOpen(false);
   }
 
+  useEffect(() => {
+    const localAuthJson = localStorage.getItem('um.auth');
+    if (localAuthJson) {
+      const localAuth = JSON.parse(localAuthJson);
+      handleSignIn(localAuth.user, localAuth.token);
+    }
+  }, [handleSignIn]);
+
   return (
     <>
       <div>
-        <div className="p-2 px-[15px] flex justify-between big:px-[50px] min-w-[300px]">
+        <div className="p-2 px-[15px] flex justify-between big:px-[50px] min-w-[350px]">
           <Link
             to="/"
             className="text-[32px] font-bold cursor-pointer"
             style={{ fontFamily: 'Arvo, serif' }}>
             NewU
           </Link>
-          {user && (
+          {readUser() && (
             <div className="flex items-center">
               <h1 className="h-fit mr-[20px] text-lg inline-block">
                 {user?.displayName}
@@ -40,7 +49,7 @@ export function Header() {
           )}
         </div>
         <hr className="border-[1px]" />
-        <div className="px-[15px] big:px-[50px] min-w-[300px]">
+        <div className="min-w-[350px]">
           <Outlet />
         </div>
       </div>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -17,7 +17,7 @@ export function Header() {
   return (
     <>
       <div>
-        <div className="p-2 px-[15px] flex justify-between sm:px-[50px]">
+        <div className="p-2 px-[15px] flex justify-between big:px-[50px] min-w-[300px]">
           <Link
             to="/"
             className="text-[32px] font-bold cursor-pointer"
@@ -40,7 +40,7 @@ export function Header() {
           )}
         </div>
         <hr className="border-[1px]" />
-        <div className="mx-[15px] sm:mx-[50px]">
+        <div className="px-[15px] big:px-[50px] min-w-[300px]">
           <Outlet />
         </div>
       </div>

--- a/client/src/components/ListCalendar.tsx
+++ b/client/src/components/ListCalendar.tsx
@@ -1,15 +1,46 @@
+import { Link } from 'react-router-dom';
 import { HabitMarker } from './HabitMarker';
 
 type Props = {
+  calendarId: number;
   name: string;
   color: string;
   mark: boolean;
 };
-export function ListCalendar({ name, color, mark }: Props) {
+export function ListCalendar({ calendarId, name, color, mark }: Props) {
+  let calDivStyle =
+    'rounded-[15px] flex justify-between items-center py-[5px] px-[10px] min-h-[75px] cursor-pointer';
+
+  switch (color) {
+    case 'red':
+      calDivStyle += ' bg-[#FFE6E6]';
+      break;
+    case 'orange':
+      calDivStyle += ' bg-[#FDF0E0]';
+      break;
+    case 'yellow':
+      calDivStyle += ' bg-[#FDFCE0]';
+      break;
+    case 'green':
+      calDivStyle += ' bg-[#DAFCD9]';
+      break;
+    case 'blue':
+      calDivStyle += ' bg-[#D9FDFF]';
+      break;
+    case 'purple':
+      calDivStyle += ' bg-[#F8EEFF]';
+      break;
+    case 'pink':
+      calDivStyle += ' bg-[#FFECFE]';
+      break;
+  }
+
   return (
-    <div>
-      <h1>{name}</h1>
-      <HabitMarker color={color} mark={mark} />
-    </div>
+    <Link to={`/calendar/${calendarId}`}>
+      <div className={calDivStyle}>
+        <span className="text-[20px]">{name}</span>
+        <HabitMarker color={color} mark={mark} />
+      </div>
+    </Link>
   );
 }

--- a/client/src/components/ListCalendar.tsx
+++ b/client/src/components/ListCalendar.tsx
@@ -1,0 +1,15 @@
+import { HabitMarker } from './HabitMarker';
+
+type Props = {
+  name: string;
+  color: string;
+  mark: boolean;
+};
+export function ListCalendar({ name, color, mark }: Props) {
+  return (
+    <div>
+      <h1>{name}</h1>
+      <HabitMarker color={color} mark={mark} />
+    </div>
+  );
+}

--- a/client/src/components/ListCalendar.tsx
+++ b/client/src/components/ListCalendar.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { HabitMarker } from './HabitMarker';
+import { convertColorLight } from '../lib';
 
 type Props = {
   calendarId: number;
@@ -8,32 +9,9 @@ type Props = {
   mark: boolean;
 };
 export function ListCalendar({ calendarId, name, color, mark }: Props) {
-  let calDivStyle =
-    'rounded-[15px] flex justify-between items-center py-[5px] px-[10px] min-h-[75px] cursor-pointer';
-
-  switch (color) {
-    case 'red':
-      calDivStyle += ' bg-[#FFE6E6]';
-      break;
-    case 'orange':
-      calDivStyle += ' bg-[#FDF0E0]';
-      break;
-    case 'yellow':
-      calDivStyle += ' bg-[#FDFCE0]';
-      break;
-    case 'green':
-      calDivStyle += ' bg-[#DAFCD9]';
-      break;
-    case 'blue':
-      calDivStyle += ' bg-[#D9FDFF]';
-      break;
-    case 'purple':
-      calDivStyle += ' bg-[#F8EEFF]';
-      break;
-    case 'pink':
-      calDivStyle += ' bg-[#FFECFE]';
-      break;
-  }
+  const calDivStyle = `rounded-[15px] flex justify-between items-center
+    py-[5px] px-[10px] min-h-[75px] cursor-pointer
+    bg-[${convertColorLight(color)}]`;
 
   return (
     <Link to={`/calendar/${calendarId}`}>

--- a/client/src/components/WeekCalendar.tsx
+++ b/client/src/components/WeekCalendar.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { HabitMarker } from './HabitMarker';
+import { convertColorLight } from '../lib';
+
+type Props = {
+  color: string;
+};
+export function WeekCalendar({ color }: Props) {
+  const [days, setDays] = useState<JSX.Element[]>([]);
+
+  const calendarStyle = `flex justify-around rounded py-[10px]
+    bg-[${convertColorLight(color)}]`;
+
+  useEffect(() => {
+    const dayArray = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+    const dayMarkerArray = dayArray.map((day, i): JSX.Element => {
+      return (
+        <div key={i}>
+          <h1 className="text-center text-[24px]">{day}</h1>
+          <HabitMarker color={color} mark={true} />
+        </div>
+      );
+    });
+
+    setDays(dayMarkerArray);
+  }, [color]);
+
+  return <div className={calendarStyle}>{days}</div>;
+}

--- a/client/src/components/WeekGoalMarker.tsx
+++ b/client/src/components/WeekGoalMarker.tsx
@@ -5,9 +5,8 @@ type Props = {
   mark: boolean;
   color: string;
 };
-export function HabitMarker({ mark, color }: Props) {
-  let buttonStyle = `rounded-full border-[5px]
-    w-[40px] h-[40px] cursor-pointer
+export function WeekGoalMarker({ mark, color }: Props) {
+  let buttonStyle = `rounded-full border-[5px] w-[50px] h-[50px] cursor-pointer
     flex justify-center items-center border-[${convertColor(color)}]`;
 
   if (!mark) {

--- a/client/src/lib/data.ts
+++ b/client/src/lib/data.ts
@@ -14,11 +14,62 @@ type Auth = {
 export function todayToString() {
   const today = new Date();
   const year = today.getFullYear().toString();
-  const monthNum = today.getMonth();
+  const monthNum = today.getMonth() + 1;
   const month = (monthNum < 10 ? '0' : '') + monthNum.toString();
   const todayNum = today.getDate();
   const date = (todayNum < 10 ? '0' : '') + todayNum.toString();
   return `${year}-${month}-${date}`;
+}
+
+/**
+ * Takes a color name and converts it into a string of a hex color.
+ * @param color A string of a color name.
+ * @returns A string of a hex code for the given color.
+ */
+export function convertColor(color: string): string {
+  switch (color) {
+    case 'red':
+      return '#FF5A5A';
+    case 'orange':
+      return '#F29930';
+    case 'yellow':
+      return '#F2EA30';
+    case 'green':
+      return '#31F22D';
+    case 'blue':
+      return '#35E6F1';
+    case 'purple':
+      return '#D289FF';
+    case 'pink':
+      return '#FF7EFA';
+    default:
+      return '#808080';
+  }
+}
+
+/**
+ * Takes a color name and converts it into a string of a hex color for a
+ * lighter version of the color.
+ * @param color A string of a color name.
+ * @returns A string of a hex code for the given color.
+ */
+export function convertColorLight(color: string) {
+  switch (color) {
+    case 'red':
+      return '#FFE6E6';
+    case 'orange':
+      return '#FDF0E0';
+    case 'yellow':
+      return '#FDFCE0';
+    case 'green':
+      return '#DAFCD9';
+    case 'blue':
+      return '#D9FDFF';
+    case 'purple':
+      return '#F8EEFF';
+    case 'pink':
+      return '#FFECFE';
+  }
 }
 
 export function saveAuth(user: User, token: string): void {
@@ -93,6 +144,7 @@ export type Calendar = {
   name: string;
   desc: string;
   color: string;
+  goal: number;
 };
 export async function readCalendars(): Promise<Calendar[]> {
   const res = await fetch('/api/calendars', {
@@ -101,6 +153,15 @@ export async function readCalendars(): Promise<Calendar[]> {
   if (!res.ok) throw new Error(`fetch Error: ${res.status}`);
   const calendars = (await res.json()) as Calendar[];
   return calendars;
+}
+
+export async function readCalendar(calendarId: string): Promise<Calendar> {
+  const res = await fetch(`/api/calendars/${calendarId}`, {
+    headers: { Authorization: ('Bearer ' + readToken()) as string },
+  });
+  if (!res.ok) throw new Error(`fetch Error: ${res.status}`);
+  const calendar = (await res.json()) as Calendar;
+  return calendar;
 }
 
 export type Mark = {

--- a/client/src/lib/data.ts
+++ b/client/src/lib/data.ts
@@ -7,6 +7,20 @@ type Auth = {
   token: string;
 };
 
+/**
+ * Converts a Date object of today's date to a string.
+ * @returns A string of the format 'yyyy-mm-dd'.
+ */
+export function todayToString() {
+  const today = new Date();
+  const year = today.getFullYear().toString();
+  const monthNum = today.getMonth();
+  const month = (monthNum < 10 ? '0' : '') + monthNum.toString();
+  const todayNum = today.getDate();
+  const date = (todayNum < 10 ? '0' : '') + todayNum.toString();
+  return `${year}-${month}-${date}`;
+}
+
 export function saveAuth(user: User, token: string): void {
   const auth: Auth = { user, token };
   localStorage.setItem(authKey, JSON.stringify(auth));
@@ -74,16 +88,34 @@ export async function signIn(params: SignInParams): Promise<Auth> {
   return user;
 }
 
-type Calendar = {
+export type Calendar = {
+  calendarId: number;
   name: string;
   desc: string;
   color: string;
 };
 export async function readCalendars(): Promise<Calendar[]> {
-  const res = await fetch('/api/calendars');
+  const res = await fetch('/api/calendars', {
+    headers: { Authorization: ('Bearer ' + readToken()) as string },
+  });
   if (!res.ok) throw new Error(`fetch Error: ${res.status}`);
   const calendars = (await res.json()) as Calendar[];
   return calendars;
+}
+
+export type Mark = {
+  calendarId: number;
+  ownerId: number;
+  date: string;
+  isCompleted: boolean;
+};
+export async function readDateMarks(date: string): Promise<Mark[]> {
+  const res = await fetch(`/api/marks/${date}`, {
+    headers: { Authorization: ('Bearer ' + readToken()) as string },
+  });
+  if (!res.ok) throw new Error(`fetch Error: ${res.status}`);
+  const marks = (await res.json()) as Mark[];
+  return marks;
 }
 
 // export type UnsavedTodo = {

--- a/client/src/pages/Calendar.tsx
+++ b/client/src/pages/Calendar.tsx
@@ -1,0 +1,3 @@
+export function Calendar() {
+  return <div></div>;
+}

--- a/client/src/pages/Calendar.tsx
+++ b/client/src/pages/Calendar.tsx
@@ -1,3 +1,0 @@
-export function Calendar() {
-  return <div></div>;
-}

--- a/client/src/pages/CalendarDetails.tsx
+++ b/client/src/pages/CalendarDetails.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Calendar, convertColor, readCalendar } from '../lib';
+import { useParams } from 'react-router-dom';
+import { WeekGoalMarker } from '../components/WeekGoalMarker';
+import { WeekCalendar } from '../components/WeekCalendar';
+
+export function CalendarDetails() {
+  const [calendar, setCalendar] = useState<Calendar>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<unknown>();
+
+  const { calendarId } = useParams();
+
+  useEffect(() => {
+    async function read() {
+      try {
+        if (!calendarId) throw new Error("shouldn't happen");
+        setCalendar(await readCalendar(calendarId));
+      } catch (err) {
+        console.error(err);
+        setError(err);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    read();
+  }, [calendarId]);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return (
+      <div>
+        Error! {error instanceof Error ? error.message : 'Unknown error'}
+      </div>
+    );
+  }
+
+  if (!calendar) {
+    return <div>Can't find this calendar :&#40;</div>;
+  }
+
+  const headerDivStyle = `bg-[${convertColor(calendar.color)}] py-[10px]
+    px-[15px]
+    big:px-[50px] min-h-[60px] flex items-center justify-between`;
+
+  return (
+    <>
+      <div className={headerDivStyle}>
+        <h1 className="text-[24px] max-w-[90%]">{calendar.name}</h1>
+      </div>
+      <div className="px-[15px] big:px-[50px]">
+        <h1>This Week</h1>
+        <div className="flex justify-between">
+          <span>
+            Your goal:
+            <br />
+            {calendar.goal} days a week
+          </span>
+          <WeekGoalMarker color={calendar.color} mark={false} />
+        </div>
+        <WeekCalendar color={calendar.color} />
+        {calendar.desc ? (
+          <>
+            <h3>Description</h3>
+            <p>{calendar.desc}</p>
+          </>
+        ) : (
+          ''
+        )}
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -93,7 +93,7 @@ export function Home() {
     'py-[5px] px-[10px] rounded bg-[#B9FBFF] cursor-pointer text-xl';
 
   return (
-    <>
+    <div className="px-[15px] big:px-[50px]">
       {!user && (
         <div className="mt-[30vh] flex justify-center">
           <div className="flex flex-col items-center">
@@ -127,6 +127,6 @@ export function Home() {
           )}
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -50,6 +50,7 @@ export function Home() {
       listCalendarArray.push(
         <ListCalendar
           key={i}
+          calendarId={c.calendarId}
           name={c.name}
           color={c.color}
           mark={dayMarkIsComplete}
@@ -116,8 +117,14 @@ export function Home() {
       )}
       {user && (
         <div className="pt-[20px]">
-          <h1 className="text-[24px]">My Habit Calendars</h1>
-          {calendarArray}
+          <h1 className="text-[24px] mb-[10px]">My Habit Calendars</h1>
+          {calendarArray.length > 0 ? (
+            calendarArray
+          ) : (
+            <p className="text-center text-gray-500">
+              You don't have any calendars yet!
+            </p>
+          )}
         </div>
       )}
     </>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,12 +1,23 @@
 import { Link } from 'react-router-dom';
 import { useUser } from '../components/useUser';
 import { useEffect, useState } from 'react';
-import { signIn } from '../lib';
+import {
+  Calendar,
+  Mark,
+  readCalendars,
+  readDateMarks,
+  signIn,
+  todayToString,
+} from '../lib';
+import { ListCalendar } from '../components/ListCalendar';
 
 export function Home() {
   const { user, handleSignIn } = useUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown>();
+  const [calendars, setCalendars] = useState<Calendar[]>([]);
+  const [marks, setMarks] = useState<Mark[]>([]);
+  const [calendarArray, setCalendarArray] = useState<JSX.Element[]>([]);
 
   useEffect(() => {
     const localAuthJson = localStorage.getItem('um.auth');
@@ -15,6 +26,38 @@ export function Home() {
       handleSignIn(localAuth.user, localAuth.token);
     }
   }, [handleSignIn]);
+
+  useEffect(() => {
+    async function read() {
+      try {
+        if (!user) return;
+        setCalendars(await readCalendars());
+        setMarks(await readDateMarks(todayToString()));
+      } catch (err) {
+        console.error(err);
+        setError(err);
+      }
+    }
+
+    read();
+  }, [user]);
+
+  useEffect(() => {
+    const listCalendarArray: JSX.Element[] = [];
+    calendars.forEach((c, i) => {
+      const dayMark = marks.find((mark) => mark.calendarId === c.calendarId);
+      const dayMarkIsComplete = dayMark ? dayMark.isCompleted : false;
+      listCalendarArray.push(
+        <ListCalendar
+          key={i}
+          name={c.name}
+          color={c.color}
+          mark={dayMarkIsComplete}
+        />
+      );
+    });
+    setCalendarArray(listCalendarArray);
+  }, [calendars, marks]);
 
   async function onDemoClick() {
     try {
@@ -25,7 +68,6 @@ export function Home() {
       };
       const { user, token } = await signIn(body);
       handleSignIn(user, token);
-      console.log('signed in', user);
     } catch (err) {
       console.error(err);
       setError(err);
@@ -50,7 +92,7 @@ export function Home() {
     'py-[5px] px-[10px] rounded bg-[#B9FBFF] cursor-pointer text-xl';
 
   return (
-    <div className="mx-[15px]">
+    <>
       {!user && (
         <div className="mt-[30vh] flex justify-center">
           <div className="flex flex-col items-center">
@@ -75,8 +117,9 @@ export function Home() {
       {user && (
         <div className="pt-[20px]">
           <h1 className="text-[24px]">My Habit Calendars</h1>
+          {calendarArray}
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -1,3 +1,3 @@
 export function NotFound() {
-  return <div>Page Not Found</div>;
+  return <div className="px-[15px] big:px-[50px]">Page Not Found</div>;
 }

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -40,7 +40,7 @@ export function Register() {
   }
 
   return (
-    <div className="mx-[15px]">
+    <>
       <h1 className="text-[24px] my-3">Register</h1>
       <form onSubmit={handleSubmit}>
         <div className="flex flex-col space-y-2">
@@ -67,9 +67,7 @@ export function Register() {
             className={inputStyle}
           />
           <div className="flex justify-between pt-2">
-            <Link
-              to="/"
-              className="w-[70px] h-[35px] flex justify-center items-center">
+            <Link to="/" className="flex justify-center items-center">
               <FaChevronLeft />
               Back
             </Link>
@@ -82,6 +80,6 @@ export function Register() {
           </div>
         </div>
       </form>
-    </div>
+    </>
   );
 }

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -40,7 +40,7 @@ export function Register() {
   }
 
   return (
-    <>
+    <div className="px-[15px] big:px-[50px]">
       <h1 className="text-[24px] my-3">Register</h1>
       <form onSubmit={handleSubmit}>
         <div className="flex flex-col space-y-2">
@@ -86,6 +86,6 @@ export function Register() {
           </div>
         </div>
       </form>
-    </>
+    </div>
   );
 }

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -75,7 +75,13 @@ export function Register() {
               type="submit"
               className="w-[70px] h-[35px] rounded flex justify-center items-center"
               style={{ backgroundColor: buttonColor }}>
-              {isLoading ? <BiLoaderCircle /> : 'Submit'}
+              {isLoading ? (
+                <div className="spin">
+                  <BiLoaderCircle />
+                </div>
+              ) : (
+                'Submit'
+              )}
             </button>
           </div>
         </div>

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -45,7 +45,7 @@ export function SignIn() {
   }
 
   return (
-    <>
+    <div className="px-[15px] big:px-[50px]">
       <h1 className="text-[24px] my-3">Sign In</h1>
       <form onSubmit={handleSubmit}>
         <div className="flex flex-col space-y-2">
@@ -84,6 +84,6 @@ export function SignIn() {
           </div>
         </div>
       </form>
-    </>
+    </div>
   );
 }

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -73,7 +73,13 @@ export function SignIn() {
               type="submit"
               className="w-[70px] h-[35px] rounded flex justify-center items-center"
               style={{ backgroundColor: buttonColor }}>
-              {isLoading ? <BiLoaderCircle /> : 'Submit'}
+              {isLoading ? (
+                <div className="spin">
+                  <BiLoaderCircle />
+                </div>
+              ) : (
+                'Submit'
+              )}
             </button>
           </div>
         </div>

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -45,7 +45,7 @@ export function SignIn() {
   }
 
   return (
-    <div className="mx-[15px]">
+    <>
       <h1 className="text-[24px] my-3">Sign In</h1>
       <form onSubmit={handleSubmit}>
         <div className="flex flex-col space-y-2">
@@ -65,9 +65,7 @@ export function SignIn() {
             type="password"
           />
           <div className="flex justify-between pt-2">
-            <Link
-              to="/"
-              className="w-[70px] h-[35px] flex justify-center items-center">
+            <Link to="/" className="flex justify-center items-center">
               <FaChevronLeft />
               Back
             </Link>
@@ -80,6 +78,6 @@ export function SignIn() {
           </div>
         </div>
       </form>
-    </div>
+    </>
   );
 }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -3,6 +3,10 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
+    screens: {
+      big: '425px',
+      // => @media (min-width: 425px) { ... }
+    },
   },
   plugins: [],
 };

--- a/database/data.sql
+++ b/database/data.sql
@@ -11,3 +11,6 @@ values
 
 insert into "calendars" ("ownerId", "type", "name", "color", "desc", "goal")
 values (1, 'normal', 'eat veggies', 'green', 'if you wanna be healthy, you gotta eat your veggies', 5);
+
+insert into "calendarAccess" ("calendarId", "userId", "accessType")
+values (1, 1, 'owner');

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE "calendars" (
 CREATE TABLE "calendarAccess" (
   "calendarId"  integer         not null,
   "userId"      integer         not null,
+  "accessType"  text            not null,
   "createdAt"   timestamptz(6)  not null default now()
 );
 
@@ -38,7 +39,8 @@ CREATE TABLE "habitMarks" (
   "ownerId"     integer         not null,
   "date"        text            not null,
   "isCompleted" boolean         not null,
-  "createdAt"   timestamptz(6)  not null default now()
+  "createdAt"   timestamptz(6)  not null default now(),
+  unique("date")
 );
 
 ALTER TABLE "calendars" ADD FOREIGN KEY ("ownerId") REFERENCES "users" ("userId");

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE "calendarAccess" (
 CREATE TABLE "habitMarks" (
   "markId"      serial          PRIMARY KEY,
   "calendarId"  integer         not null,
+  "ownerId"     integer         not null,
   "date"        text            not null,
   "isCompleted" boolean         not null,
   "createdAt"   timestamptz(6)  not null default now()
@@ -47,3 +48,5 @@ ALTER TABLE "calendarAccess" ADD FOREIGN KEY ("calendarId") REFERENCES "calendar
 ALTER TABLE "calendarAccess" ADD FOREIGN KEY ("userId") REFERENCES "users" ("userId");
 
 ALTER TABLE "habitMarks" ADD FOREIGN KEY ("calendarId") REFERENCES "calendars" ("calendarId");
+
+ALTER TABLE "habitMarks" ADD FOREIGN KEY ("ownerId") REFERENCES "users" ("userId");

--- a/server/server.ts
+++ b/server/server.ts
@@ -112,6 +112,29 @@ app.get('/api/calendars', authMiddleware, async (req, res, next) => {
   }
 });
 
+app.get(
+  '/api/calendars/:calendarId',
+  authMiddleware,
+  async (req, res, next) => {
+    try {
+      const { calendarId } = req.params;
+      const sql = `
+        select *
+        from "calendars"
+        where "calendarId" = $1
+          and "ownerId" = $2
+        order by "calendarId";
+      `;
+      const result = await db.query(sql, [calendarId, req.user?.userId]);
+      const calendar = result.rows[0];
+      if (!calendar) throw new ClientError(400, 'calendar not found');
+      res.json(calendar);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
 // gets a list of all the markers for a specified date belonging to the current user
 app.get('/api/marks/:date', authMiddleware, async (req, res, next) => {
   try {
@@ -123,6 +146,22 @@ app.get('/api/marks/:date', authMiddleware, async (req, res, next) => {
         and "ownerId" = $2;
     `;
     const result = await db.query(sql, [date, req.user?.userId]);
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/api/marks/:calendarId', authMiddleware, async (req, res, next) => {
+  try {
+    const { calendarId } = req.params;
+    const sql = `
+      select *
+      from "habitMarks"
+      where "calendarId" = $1
+        and "ownerId" = $2;
+    `;
+    const result = await db.query(sql, [calendarId, req.user?.userId]);
     res.json(result.rows);
   } catch (err) {
     next(err);


### PR DESCRIPTION
I forgot make a new branch for viewing calendar details, so I just grouped them together in one PR.

On the home page, a list of the user's calendars will be displayed. You can click on one to bring up a page with its details. Currently the habit marker on the list is accurate, but cannot be changed, and the markers in the details are not accurate or changeable.

A few issues that I might need to fix:
- The load time for the calendar list is a bit longer than I'd like
- Having multiple fetch requests probably isn't ideal. I could try to use sql table joining to reduce to one fetch.